### PR TITLE
chore: resolve helper package audit advisories

### DIFF
--- a/.github/commands/package.json
+++ b/.github/commands/package.json
@@ -4,6 +4,17 @@
   "description": "Scripts for automated minecraft asset updates",
   "main": "bump.js",
   "dependencies": {
-    "gh-helpers": "^0.3.5"
+    "gh-helpers": "^1.2.0"
+  },
+  "overrides": {
+    "@actions/artifact": "5.0.3",
+    "@actions/github": "8.0.0",
+    "@actions/http-client": "3.0.2",
+    "@octokit/core": "7.0.6",
+    "@octokit/graphql": "9.0.2",
+    "@octokit/plugin-paginate-rest": "14.0.0",
+    "@octokit/request": "10.0.7",
+    "@octokit/request-error": "7.1.0",
+    "undici": "6.25.0"
   }
 }


### PR DESCRIPTION
Updates the GitHub commands helper package manifest so a generated npm audit lockfile reports zero vulnerabilities.\n\nChanges:\n- update gh-helpers to ^1.2.0\n- force patched CommonJS-compatible @actions/@octokit/undici versions with npm overrides\n\nVerification:\n- npm audit --json in .github/commands\n- require('gh-helpers') API load check